### PR TITLE
[VSC-7] Support cache in the extension

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1580,7 +1580,6 @@ documents.onDidChangeContent((event) => {
     if (uri === validatingUri) {
         clearTimeout(validatingTimeout);
     }
-    notify(document);
     validatingUri = uri;
     validatingTimeout = setTimeout(() => {
         notify(document);


### PR DESCRIPTION
Problem: We'd like to speed up the extension by adding a cache for unchanged files.

Solution: Use the new `parseMotokoTypedLsp` function, store its cache, and give back this cache to the function on each typed run.

Note: The `notify` function is called twice, which severely degrades performance. The extraneous call is removed.