### PR TITLE
[VSC-7] Support cache in the extension

### DIFF
--- a/__mocks__/ic-mops/commands/add.js
+++ b/__mocks__/ic-mops/commands/add.js
@@ -1,0 +1,5 @@
+module.exports = {
+    add: jest.fn(async () => {
+        return;
+    }),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
             "dependencies": {
                 "@wasmer/wasi": "1.2.2",
                 "change-case": "4.1.2",
+                "dependency-graph": "^1.0.0",
                 "execa": "4.1.0",
                 "fast-glob": "3.2.12",
                 "ic-mops": "0.45.3",
@@ -5067,6 +5068,15 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
             "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+        },
+        "node_modules/dependency-graph": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
+            "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/deprecation": {
             "version": "2.3.1",
@@ -12278,6 +12288,7 @@
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
             "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+            "license": "WTFPL OR ISC",
             "dependencies": {
                 "truncate-utf8-bytes": "^1.0.0"
             }
@@ -13038,6 +13049,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
             "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+            "license": "WTFPL",
             "dependencies": {
                 "utf8-byte-length": "^1.0.1"
             }
@@ -13431,9 +13443,10 @@
             "integrity": "sha512-Y4aqgkKbDAZn0b7T/OhX3OCEZik/Q8VsBika15m/McjebOdLC5JEBaehHZQng2VUU1I7Y+658oE2H+3XX1s2Fw=="
         },
         "node_modules/utf8-byte-length": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-            "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+            "license": "(WTFPL OR MIT)"
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
@@ -17444,6 +17457,11 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
             "integrity": "sha512-a02fiQ7poS5CnjiJBAsjGLPp5EwVoGHNeu9sziBd9huppRfsAFIpv5zNLv0V1gbop53ilngAf5Kf331AwcoRBQ=="
+        },
+        "dependency-graph": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-1.0.0.tgz",
+            "integrity": "sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg=="
         },
         "deprecation": {
             "version": "2.3.1",
@@ -23275,9 +23293,9 @@
             "integrity": "sha512-Y4aqgkKbDAZn0b7T/OhX3OCEZik/Q8VsBika15m/McjebOdLC5JEBaehHZQng2VUU1I7Y+658oE2H+3XX1s2Fw=="
         },
         "utf8-byte-length": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
-            "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA=="
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+            "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA=="
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "dependencies": {
         "@wasmer/wasi": "1.2.2",
         "change-case": "4.1.2",
+        "dependency-graph": "^1.0.0",
         "execa": "4.1.0",
         "fast-glob": "3.2.12",
         "ic-mops": "0.45.3",

--- a/src/server/bench/benchmark-did-change.ts
+++ b/src/server/bench/benchmark-did-change.ts
@@ -72,5 +72,26 @@ createBenchmark('didChange', async (setup: Setup) => {
             textDocument: { uri: document.uri },
             position: { line: 39, character: 0 }, // NOTE: doesn't matter
         });
+
+        await setup.sendNotification(
+            'textDocument/didChange',
+            {
+                textDocument: {
+                    uri: document.uri,
+                    version: 1,
+                },
+                contentChanges: [
+                    {
+                        text: document.text,
+                    },
+                ],
+            },
+            100,
+        );
+
+        await setup.benchmark<Hover>('textDocument/hover', {
+            textDocument: { uri: document.uri },
+            position: { line: 39, character: 0 }, // NOTE: doesn't matter
+        });
     });
 });

--- a/src/server/depgraph.ts
+++ b/src/server/depgraph.ts
@@ -1,0 +1,42 @@
+import { DepGraph as DG } from 'dependency-graph';
+
+export default class DepGraph {
+    private readonly _depGraph = new DG<string>({ circular: false });
+
+    clear() {
+        for (const node of this._depGraph.overallOrder()) {
+            this._depGraph.removeNode(node);
+        }
+    }
+
+    add(node: string) {
+        this._depGraph.addNode(node);
+    }
+
+    delete(node: string): boolean {
+        const hasNode = this._depGraph.hasNode(node);
+        this._depGraph.removeNode(node);
+        return hasNode;
+    }
+
+    addImmediateImports(from: string, immediateImports: string[]) {
+        for (const immediateImport of immediateImports) {
+            this._depGraph.addNode(immediateImport);
+            this._depGraph.addDependency(from, immediateImport);
+        }
+    }
+
+    transitiveDependencies(node: string): string[] {
+        return this._depGraph.dependenciesOf(node, false);
+    }
+
+    transitiveDependents(node: string): string[] {
+        return this._depGraph.dependentsOf(node, false);
+    }
+
+    removeImmediateDependencies(node: string) {
+        for (const file of this.transitiveDependencies(node)) {
+            this._depGraph.removeDependency(node, file);
+        }
+    }
+}

--- a/src/server/depgraph.ts
+++ b/src/server/depgraph.ts
@@ -1,7 +1,9 @@
 import { DepGraph as DG } from 'dependency-graph';
 
 export default class DepGraph {
-    private readonly _depGraph = new DG<string>({ circular: false });
+    // Motoko doesn't allow for circular imports, however, we allow it in the
+    // extension to avoid exceptions from this module.
+    private readonly _depGraph = new DG<string>({ circular: true });
 
     clear() {
         for (const node of this._depGraph.overallOrder()) {

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1632,7 +1632,6 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         if (uri === validatingUri) {
             clearTimeout(validatingTimeout);
         }
-        notify(document);
         validatingUri = uri;
         validatingTimeout = setTimeout(() => {
             notify(document);

--- a/src/server/server.spec.ts
+++ b/src/server/server.spec.ts
@@ -1,7 +1,173 @@
 import icCandid from '../generated/aaaaa-aa.did';
+import { Hover } from 'vscode';
+import { InitializeResult } from 'vscode-languageclient/node';
+import { Connection } from 'vscode-languageserver/node';
+import { URI } from 'vscode-uri';
+import * as fs from 'node:fs';
+import { clientInitParams, setupClientServer, wait } from './bench/helpers';
+import { join } from 'node:path';
 
 describe('server', () => {
     test('generated IC Candid file has expected format', () => {
         expect(icCandid).toContain('service ic : {\n');
+    });
+});
+
+describe('cache', () => {
+    beforeAll(() => {
+        jest.mock('ic-mops/commands/add');
+    });
+
+    const rootUri = URI.parse(join(__dirname, '..', '..', 'test', 'cache'));
+
+    function makeTextDocument(
+        file: string,
+        version: number = 1,
+    ): {
+        uri: string;
+        version: number;
+        text: string;
+        languageId: string;
+    } {
+        const uri = join(rootUri.fsPath, file);
+        return {
+            uri,
+            version,
+            text: fs.readFileSync(uri, 'utf-8'),
+            languageId: 'motoko',
+        };
+    }
+
+    async function runTest<T>(test: (client: Connection) => Promise<T>) {
+        const [client, _server] = setupClientServer();
+        await client.sendRequest<InitializeResult>(
+            'initialize',
+            clientInitParams(rootUri),
+        );
+        await client.sendNotification('initialized', {});
+        await wait(1); // wait for initialization
+        const result = await test(client);
+        await client.sendRequest('shutdown');
+        await wait(1); // wait for shutdown
+        return result;
+    }
+
+    test('Top.mo has correct hover', async () => {
+        const hover = await runTest(async (client) => {
+            const textDocument = makeTextDocument('Top.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument,
+            });
+            return client.sendRequest<Hover>('textDocument/hover', {
+                textDocument,
+                position: { line: 5, character: 21 },
+            });
+        });
+        expect(hover.contents).toStrictEqual({
+            kind: 'markdown',
+            value: '```motoko\nmodule { top : { foo : () -> () } }\n\n```',
+        });
+    });
+
+    test('Top.mo has correct hover after changing value', async () => {
+        const hover = await runTest(async (client) => {
+            const textDocument = makeTextDocument('Top.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument,
+            });
+            await client.sendNotification('textDocument/didChange', {
+                textDocument,
+                contentChanges: [
+                    {
+                        text: textDocument.text
+                            .replace(': ()', ': Nat')
+                            .replace('Bottom.bottom.bar()', '42'),
+                    },
+                ],
+            });
+            return await client.sendRequest<Hover>('textDocument/hover', {
+                textDocument,
+                position: { line: 5, character: 21 },
+            });
+        });
+        expect(hover.contents).toStrictEqual({
+            kind: 'markdown',
+            value: '```motoko\nmodule { top : { foo : () -> () } }\n\n```',
+        });
+    });
+
+    test('Top.mo has correct hover for changed dependency', async () => {
+        // Hover will get the typed AST
+        const hover = await runTest(async (client) => {
+            const textDocumentTop = makeTextDocument('Top.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument: textDocumentTop,
+            });
+            const textDocumentBottom = makeTextDocument('Bottom.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument: textDocumentBottom,
+            });
+            await client.sendNotification('textDocument/didChange', {
+                textDocument: textDocumentBottom,
+                contentChanges: [
+                    {
+                        text: textDocumentBottom.text
+                            .replace(': ()', ': Nat')
+                            .replace('return ()', 'return 42'),
+                    },
+                ],
+            });
+            await client.sendNotification('textDocument/didChange', {
+                textDocument: textDocumentTop,
+                contentChanges: [
+                    {
+                        text: textDocumentTop.text.replace(': ()', ': Nat'),
+                    },
+                ],
+            });
+            await wait(1); // wait for changes to complete
+            return await client.sendRequest<Hover>('textDocument/hover', {
+                textDocument: textDocumentTop,
+                position: { line: 5, character: 21 },
+            });
+        });
+        expect(hover.contents).toStrictEqual({
+            kind: 'markdown',
+            value: '```motoko\nmodule { top : { foo : () -> Nat } }\n\n```',
+        });
+    });
+
+    test('Top.mo has correct hover for changed dependency without changing itself', async () => {
+        // Hover will get the typed AST
+        const hover = await runTest(async (client) => {
+            const textDocumentTop = makeTextDocument('Top.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument: textDocumentTop,
+            });
+            const textDocumentBottom = makeTextDocument('Bottom.mo');
+            await client.sendNotification('textDocument/didOpen', {
+                textDocument: textDocumentBottom,
+            });
+            await client.sendNotification('textDocument/didChange', {
+                textDocument: textDocumentBottom,
+                contentChanges: [
+                    {
+                        text: textDocumentBottom.text.replace(
+                            'bottom {',
+                            'bottom { public let foo : Nat = 42;',
+                        ),
+                    },
+                ],
+            });
+            await wait(1); // wait for changes to complete
+            return await client.sendRequest<Hover>('textDocument/hover', {
+                textDocument: textDocumentTop,
+                position: { line: 4, character: 49 },
+            });
+        });
+        expect(hover.contents).toStrictEqual({
+            kind: 'markdown',
+            value: '```motoko\n{ bar : () -> (); foo : Nat }\n\n```',
+        });
     });
 });

--- a/test/cache/Bottom.mo
+++ b/test/cache/Bottom.mo
@@ -1,0 +1,5 @@
+module {
+    public object bottom {
+        public func bar() : () { return (); };
+    };
+}

--- a/test/cache/Top.mo
+++ b/test/cache/Top.mo
@@ -1,0 +1,7 @@
+import Bottom "Bottom"
+
+module {
+    public object top {
+        public func foo() : () { return Bottom.bottom.bar(); };
+    };
+}


### PR DESCRIPTION
 Problem: We'd like to speed up the extension by adding a cache for unchanged files.
    
Solution: For the typed run, use the new `parseMotokoTypedLsp` function, store its cache, and give back this cache to the function on each typed run. For the untyped run, use the new `parseMotokoWithDeps`. For both cases, manage a build graph and use it to figure out when to remove things from the cache.