### PR TITLE
[VSC-7] Fix errors on initialization

### DIFF
--- a/src/common/connectionTypes.ts
+++ b/src/common/connectionTypes.ts
@@ -54,3 +54,11 @@ export const IMPORT_MOPS_PACKAGE = new RequestType<
     Promise<TextEdit[]>,
     any
 >('vscode-motoko/install-mops-package');
+
+export const TEST_GET_DEPENDENCY_GRAPH = new RequestType<
+    {
+        uri: string;
+    },
+    [string, string[]][],
+    any
+>('vscode-motoko/test-get-dependency-graph');

--- a/src/server/ast.ts
+++ b/src/server/ast.ts
@@ -20,6 +20,11 @@ export interface AstImport {
 
 export const globalASTCache = new Map<string, AstStatus>(); // Share non-typed ASTs across all contexts
 
+// When using the functions in this class, consider the invariant that the file
+// loaded by a given URI should be written to the virtual filesystem, as well as
+// all of its dependencies. If the virtual filesystem is not ready, then
+// `withDeps` should be false. Requesting the typed AST always does dependency
+// analysis.
 export default class AstResolver {
     private readonly _cache = globalASTCache;
     private readonly _typedCache = new Map<string, AstStatus>();
@@ -36,19 +41,20 @@ export default class AstResolver {
         this._scopeCache.clear();
     }
 
-    update(uri: string, typed: boolean): boolean {
+    update(uri: string, typed: boolean, withDeps: boolean): boolean {
         const text = tryGetFileText(uri);
         if (!text) {
             this.delete(uri);
             return true;
         }
-        return this._updateWithFileText(uri, text, typed);
+        return this._updateWithFileText(uri, text, typed, withDeps);
     }
 
     private _updateWithFileText(
         uri: string,
         text: string,
         typed: boolean,
+        withDeps: boolean,
     ): boolean {
         const cache = typed ? this._typedCache : this._cache;
         let status = cache.get(uri);
@@ -88,10 +94,14 @@ export default class AstResolver {
                     ast = prog.ast;
                     immediateImports = prog.immediateImports;
                     this._scopeCache = scopeCache;
-                } else {
+                } else if (withDeps) {
                     const prog = motoko.parseMotokoWithDeps(virtualPath, text);
                     ast = prog.ast;
                     immediateImports = prog.immediateImports;
+                } else {
+                    const prog = motoko.parseMotoko(text);
+                    ast = prog;
+                    immediateImports = [];
                 }
             } catch (err) {
                 throw new SyntaxError(String(err));
@@ -111,7 +121,7 @@ export default class AstResolver {
             }
             return true;
         } catch (err) {
-            if (!(err instanceof SyntaxError)) {
+            if (err instanceof SyntaxError) {
                 console.error(`Error while parsing AST for ${uri}:`);
                 console.error(err);
             }
@@ -120,9 +130,12 @@ export default class AstResolver {
         }
     }
 
-    request(uri: string): AstStatus | undefined {
+    request(uri: string, withDeps: boolean): AstStatus | undefined {
         const status = this._cache.get(uri);
-        if ((!status || status.outdated) && !this.update(uri, false)) {
+        if (
+            (!status || status.outdated) &&
+            !this.update(uri, false, withDeps)
+        ) {
             return status;
         }
         return this._cache.get(uri);
@@ -130,13 +143,13 @@ export default class AstResolver {
 
     requestTyped(uri: string): AstStatus | undefined {
         const status = this._typedCache.get(uri);
-        if ((!status || status.outdated) && !this.update(uri, true)) {
+        if ((!status || status.outdated) && !this.update(uri, true, true)) {
             return status;
         }
         return this._typedCache.get(uri);
     }
 
-    notify(uri: string, source: string) {
+    notify(uri: string, source: string, withDeps: boolean) {
         // const status = this._cache.get(uri);
         // if (status) {
         //     status.outdated = true;
@@ -145,7 +158,7 @@ export default class AstResolver {
         if (typedStatus) {
             typedStatus.outdated = true;
         }
-        this._updateWithFileText(uri, source, false);
+        this._updateWithFileText(uri, source, false, withDeps);
     }
 
     delete(uri: string): boolean {
@@ -154,5 +167,9 @@ export default class AstResolver {
         const deletedGraph = this._depGraph.delete(uri);
         const deletedCache = this._scopeCache.delete(uri);
         return deleted || deletedTyped || deletedGraph || deletedCache;
+    }
+
+    getDependencyGraph(): DepGraph {
+        return this._depGraph;
     }
 }

--- a/src/server/ast.ts
+++ b/src/server/ast.ts
@@ -95,9 +95,22 @@ export default class AstResolver {
                     immediateImports = prog.immediateImports;
                     this._scopeCache = scopeCache;
                 } else if (withDeps) {
-                    const prog = motoko.parseMotokoWithDeps(virtualPath, text);
-                    ast = prog.ast;
-                    immediateImports = prog.immediateImports;
+                    try {
+                        const prog = motoko.parseMotokoWithDeps(
+                            virtualPath,
+                            text,
+                        );
+                        ast = prog.ast;
+                        immediateImports = prog.immediateImports;
+                    } catch (err) {
+                        console.error(
+                            'Error while parsing Motoko with deps, retrying',
+                        );
+                        console.error(err);
+                        const prog = motoko.parseMotoko(text);
+                        ast = prog;
+                        immediateImports = [];
+                    }
                 } else {
                     const prog = motoko.parseMotoko(text);
                     ast = prog;

--- a/src/server/depgraph.ts
+++ b/src/server/depgraph.ts
@@ -41,4 +41,8 @@ export default class DepGraph {
             this._depGraph.removeDependency(node, file);
         }
     }
+
+    getRawGraph(): DG<string> {
+        return this._depGraph;
+    }
 }

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -43,6 +43,7 @@ import {
     IMPORT_MOPS_PACKAGE,
     TEST_FILE_REQUEST,
     TestResult,
+    TEST_GET_DEPENDENCY_GRAPH,
 } from '../common/connectionTypes';
 import {
     ignoreGlobPatterns,
@@ -232,9 +233,11 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         return sources;
     }
 
+    let isVirtualFileSystemReady = false;
     let loadingPackages = false;
     let packageConfigChangeTimeout: ReturnType<typeof setTimeout>;
     function notifyPackageConfigChange(reuseCached = false) {
+        isVirtualFileSystemReady = false;
         isWorkspaceReady = false;
         if (!reuseCached) {
             packageSourceCache.clear();
@@ -385,7 +388,9 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                 // NOTE: Useful for tests and benchmarks.
                 // Unknown notifications are ignored by the vscode lsp client.
                 connection.sendNotification('custom/initialized', {});
+                isVirtualFileSystemReady = true;
             } catch (err: any) {
+                isVirtualFileSystemReady = false;
                 loadingPackages = false;
                 console.error(
                     `Error while loading packages: ${err?.message || err}`,
@@ -547,7 +552,10 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         context: Context,
         importPath: string,
     ): Position {
-        const imports = context.astResolver.request(uri)?.program?.imports;
+        const imports = context.astResolver.request(
+            uri,
+            isVirtualFileSystemReady,
+        )?.program?.imports;
         if (imports?.length) {
             let lastImport = imports[imports.length - 1];
 
@@ -1033,7 +1041,7 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                 const { astResolver, importResolver } = context;
                 let program: Program | undefined;
                 try {
-                    astResolver.notify(uri, content);
+                    astResolver.notify(uri, content, isVirtualFileSystemReady);
                     // program = astResolver.request(uri)?.program; // TODO: re-enable for field imports
                 } catch (err) {
                     console.error(`Error while parsing (${uri}): ${err}`);
@@ -1064,7 +1072,10 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         const results: CodeAction[] = [];
 
         // Organize imports
-        const status = getContext(uri).astResolver.request(uri);
+        const status = getContext(uri).astResolver.request(
+            uri,
+            isVirtualFileSystemReady,
+        );
         const imports = status?.program?.imports;
         if (imports?.length) {
             const start = rangeFromNode(asNode(imports[0].ast))?.start;
@@ -1142,7 +1153,11 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
             const text = getFileText(uri);
             const lines = text.split(/\r?\n/g);
             const context = getContext(uri);
-            const program = context.astResolver.request(uri)?.program;
+            const status = context.astResolver.request(
+                uri,
+                isVirtualFileSystemReady,
+            );
+            const program = status?.program;
 
             const [dot, identStart] = /(\s*\.\s*)?([a-zA-Z_]?[a-zA-Z0-9_]*)$/
                 .exec(lines[position.line].substring(0, position.character))
@@ -1158,8 +1173,6 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                                 const path = importPath.startsWith('mo:')
                                     ? importPath
                                     : getRelativeUri(uri, importPath);
-
-                                const status = context.astResolver.request(uri);
                                 const existingImport =
                                     status?.program?.imports.find(
                                         (i) =>
@@ -1480,7 +1493,10 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
     connection.onDocumentSymbol((event) => {
         const { uri } = event.textDocument;
         const results: DocumentSymbol[] = [];
-        const status = getContext(uri).astResolver.request(uri);
+        const status = getContext(uri).astResolver.request(
+            uri,
+            isVirtualFileSystemReady,
+        );
         status?.program?.exportFields.forEach((field) => {
             results.push(...getDocumentSymbols(field, false));
         });
@@ -1648,6 +1664,15 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         } else {
             return [];
         }
+    });
+
+    // Install and import mops package
+    connection.onRequest(TEST_GET_DEPENDENCY_GRAPH, (params) => {
+        const graph = getContext(params.uri)
+            .astResolver.getDependencyGraph()
+            .getRawGraph();
+        const nodes = graph.overallOrder(false);
+        return nodes.map((node) => [node, graph.directDependenciesOf(node)]);
     });
 
     const diagnosticMap = new Map<string, Diagnostic[]>();

--- a/src/server/navigation.ts
+++ b/src/server/navigation.ts
@@ -128,7 +128,7 @@ export function findDefinition(
 ): Definition | undefined {
     // Get relevant AST node
     const context = getContext(uri);
-    const status = context.astResolver.request(uri);
+    const status = context.astResolver.request(uri, false);
     if (!status?.ast) {
         console.warn('Missing AST for', uri);
         return;
@@ -261,7 +261,7 @@ function followImport(
             console.log('Unknown file system URI for path:', path);
             return;
         }
-        const status = context.astResolver.request(uri);
+        const status = context.astResolver.request(uri, false);
         if (!status?.program?.export?.ast) {
             console.log('Missing export for', uri);
             return;


### PR DESCRIPTION
Problem: There are some errors during the initialization of the extension due `parseMotokoWithDeps` failing to analyze dependencies due to the virtual file system not being completed yet. Althoguh these errors do not worsen user interface, it's best to solve them.

Solution: Pass a flag indicating whether to get dependencies or not to the AST resolver. This is controlled based on whether the virtual filesystem is being loaded or not (using a new flag). Expose a request to get the dependency graph and write a test using it.

Also, I now log any errors that might happen from the AST resolver.