### PR TITLE
[VSC-32] Implement signature help

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -26,7 +26,6 @@ import {
     Position,
     Range,
     ReferenceParams,
-    SignatureHelp,
     SymbolKind,
     TextDocumentPositionParams,
     TextDocumentSyncKind,
@@ -99,6 +98,7 @@ import {
     resolveFilePath,
     resolveVirtualPath,
 } from './utils';
+import { mkOnSignatureHelpHandler } from './handlers/onSignatureHelp';
 
 import execa = require('execa');
 
@@ -654,6 +654,10 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
                 // executeCommandProvider: { commands: [] },
                 workspaceSymbolProvider: true,
                 documentSymbolProvider: true,
+                signatureHelpProvider: {
+                    triggerCharacters: ['(', ','],
+                    retriggerCharacters: [','],
+                },
                 // diagnosticProvider: {
                 //     documentSelector: ['motoko'],
                 //     interFileDependencies: true,
@@ -1171,9 +1175,7 @@ export const addHandlers = (connection: Connection, redirectConsole = true) => {
         return results;
     });
 
-    connection.onSignatureHelp((): SignatureHelp | null => {
-        return null;
-    });
+    connection.onSignatureHelp(mkOnSignatureHelpHandler(documents));
 
     function findImportUri(
         context: Context,

--- a/src/server/handlers/onSignatureHelp.ts
+++ b/src/server/handlers/onSignatureHelp.ts
@@ -1,0 +1,269 @@
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { AST, Node } from 'motoko/lib/ast';
+import {
+    SignatureHelp,
+    SignatureHelpParams,
+    CancellationToken,
+    TextDocuments,
+} from 'vscode-languageserver/node';
+
+import { getContext } from '../context';
+import { findNodes } from '../syntax';
+
+/**
+ * Creates a handler for the onSignatureHelp event
+ *
+ * @param documents The document manager
+ * @returns The onSignatureHelp event handler
+ */
+export function mkOnSignatureHelpHandler(
+    documents: TextDocuments<TextDocument>,
+): (
+    params: SignatureHelpParams,
+    _token: CancellationToken,
+) => SignatureHelp | null {
+    const paramsRe = /^.*?\((.+)\)\s*->/; // Regular expression to extract parameters from function type
+    return (params, _token) => {
+        const { textDocument, position, context } = params;
+        if (!context) return null;
+        const { uri } = textDocument;
+        const doc = documents.get(uri);
+        if (!doc) return null;
+        const { astResolver } = getContext(uri);
+        const status = astResolver.requestTyped(uri);
+        if (!status || !status.ast) return null;
+        const cursorOffset = doc.offsetAt(position);
+        const funcNodes = findFuncNodes(status.ast, doc, cursorOffset);
+        if (!funcNodes.length) return null;
+        const text = doc.getText();
+        let i = 0;
+        let activeParameter = undefined;
+        let fInfo = null;
+        while (i < funcNodes.length && activeParameter === undefined) {
+            fInfo = funcInfo(funcNodes[i], doc);
+            activeParameter = getActiveParamIndex(
+                fInfo.offset,
+                text,
+                cursorOffset,
+            );
+            i++;
+        }
+        if (activeParameter === undefined) return null;
+        const { funcName, funcType } = fInfo as any;
+        const paramsString = funcType.match(paramsRe)?.[1] ?? '';
+        const startIndex = funcName.length + funcType.indexOf(paramsString);
+        const funcParams = splitParams(paramsString, startIndex);
+        return {
+            signatures: [
+                {
+                    label: `${funcName}${funcType}`,
+                    parameters: funcParams.map((p) => ({ label: p })),
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: activeParameter,
+        };
+    };
+}
+
+/**
+ * Calculates the current parameter index
+ *
+ * @param paramOffset Usually the offset of the first caracter after function name
+ * @param text Document text
+ * @param cursorOffset Offset of current cursor position
+ * @returns Parameter index or undefined if current cursor position is outside
+ * function signature
+ */
+function getActiveParamIndex(
+    paramOffset: number,
+    text: string,
+    cursorOffset: number,
+): number | undefined {
+    let paren = 0,
+        brack = 0,
+        brace = 0,
+        angle = 0,
+        index = 0;
+    if (cursorOffset == paramOffset) return undefined;
+    let i = paramOffset;
+    while (i < cursorOffset) {
+        i = skipBlockComment(text, i, cursorOffset);
+        i = skipString(text, i, cursorOffset);
+        if (i > cursorOffset) break;
+        const ch = text[i];
+        if (ch === '(') paren++;
+        if (ch === ')') {
+            paren--;
+            if (paren === 0) return undefined;
+        }
+        if (ch === '[') brack++;
+        if (ch === ']') brack--;
+        if (ch === '{') brace++;
+        if (ch === '}') brace--;
+        if (ch === '<') angle++;
+        if (ch === '>') angle--;
+        if (ch === ',' && paren == 1 && !brack && !brace && !angle) {
+            index++;
+        }
+        i++;
+    }
+    if (paren <= 0) return undefined;
+    return index;
+}
+
+/**
+ * Skips block comment if it starts at `offset`. Returns the offset of the first
+ * character after the end of comment. Otherwise returns original offset.
+ *
+ * @param text The text of document
+ * @param offset Current offset in the document
+ * @return Offset of the first caracter after the comment or original offset
+ * */
+function skipBlockComment(
+    text: string,
+    offset: number,
+    cursorOffset: number,
+): number {
+    if (text.slice(offset, offset + 2) === '/*') {
+        let i = offset + 2;
+        while (i < cursorOffset && text.slice(i, i + 2) !== '*/') i++;
+        return i + 2;
+    }
+    return offset;
+}
+
+/**
+ * Skips string if it starts at `offset`. Returns the offset of the first
+ * character after the end of string. Otherwise returns original offset.
+ *
+ * @param text The text of document
+ * @param offset Current offset in the document
+ * @return Offset of the first caracter after the string or original offset
+ * */
+function skipString(
+    text: string,
+    offset: number,
+    cursorOffset: number,
+): number {
+    if (text[offset] === '"') {
+        let i = offset + 1;
+        while (i < cursorOffset && !(text[i] === '"' && text[i - 1] !== '\\'))
+            i++;
+        return i + 1;
+    }
+    return offset;
+}
+
+/**
+ * Splits the single parameters string to the list of parameters
+ *
+ * @param pString Function parameters string
+ * @returns List of parameters
+ */
+function splitParams(
+    paramsString: string,
+    startIndex: number,
+): [number, number][] {
+    let paren = 0;
+    let brack = 0;
+    let brace = 0;
+    let start = 0;
+    const params: [number, number][] = [];
+    for (let i = 0; i < paramsString.length; i++) {
+        const ch = paramsString[i];
+        if (ch === '(') paren++;
+        if (ch === ')') paren--;
+        if (ch === '[') brack++;
+        if (ch === ']') brack--;
+        if (ch === '{') brace++;
+        if (ch === '}') brace--;
+        if (ch === ',' && !paren && !brack && !brace) {
+            params.push([startIndex + start, startIndex + i]);
+            start = i + 1;
+        }
+    }
+    params.push([startIndex + start, startIndex + paramsString.length]);
+    return params;
+}
+
+/**
+ * Finds all nodes with function names before current cursor position related to
+ * function calls. Returns nodes in order starting from nearest to current cursor
+ * position.
+ *
+ * @param ast Current AST
+ * @param doc Current document
+ * @param cursorOffset The offset of current cursor position
+ * @returns List of Nodes near to the current cursor position containing function
+ * information
+ * */
+function findFuncNodes(
+    ast: AST,
+    doc: TextDocument,
+    cursorOffset: number,
+): Node[] {
+    function posDesc(a: Node, b: Node): number {
+        if (!(a.start && b.start)) return 0;
+        const aStartOffset = doc.offsetAt({
+            line: a.start[0] - 1,
+            character: a.start[1],
+        });
+        const bStartOffset = doc.offsetAt({
+            line: b.start[0] - 1,
+            character: b.start[1],
+        });
+        return bStartOffset - aStartOffset;
+    }
+    const nodes = findNodes(ast, funcNodesPred(doc, cursorOffset))
+        .map((n) => (n as any).args[0])
+        .sort(posDesc);
+    return nodes;
+}
+
+/**
+ * Creates a predicate for `findNodes` function to find nodes related to function calls
+ *
+ * @param doc Current document
+ * @param cursorOffset Current cursor offset
+ * @returns Predicate for `findNodes`
+ * */
+function funcNodesPred(
+    doc: TextDocument,
+    cursorOffset: number,
+): (node: Node, parents: Node[]) => any {
+    return (node: Node, _parents: Node[]) => {
+        if (!(node.start && node.end && node.typeRep)) return false;
+        const endOffset = doc.offsetAt({
+            line: node.end[0] - 1,
+            character: node.end[1] - 1,
+        });
+        const funcCond =
+            node.name === 'VarE' &&
+            node.typeRep.name === 'Func' &&
+            cursorOffset > endOffset;
+        if (funcCond) return true;
+        return false;
+    };
+}
+
+/**
+ * Extracts function name, function type and offset of function name end position.
+ *
+ * @param node The node containing function information found by `findFuncNodes`
+ * @param doc Current document
+ * @returns An object with function information
+ * */
+function funcInfo(
+    node: Node,
+    doc: TextDocument,
+): { funcName: string; offset: number; funcType: string } {
+    return {
+        funcName: (node as any).args[0],
+        offset: doc.offsetAt({
+            line: (node as any).end[0] - 1,
+            character: (node as any).end[1],
+        }),
+        funcType: node.type as string,
+    };
+}

--- a/src/server/test/signatureHelp.spec.ts
+++ b/src/server/test/signatureHelp.spec.ts
@@ -1,0 +1,620 @@
+import {
+    Connection,
+    InitializeResult,
+    SignatureHelp,
+} from 'vscode-languageserver/node';
+import { URI } from 'vscode-uri';
+import { clientInitParams, setupClientServer } from './mock';
+import { cwd } from 'node:process';
+import { wait, waitForNotification } from './helpers';
+import { readFileSync } from 'node:fs';
+
+jest.setTimeout(60000);
+
+const filePath = `${cwd()}/test/signatureHelp`;
+const rootUri = URI.file(filePath);
+const text = readFileSync(`${filePath}/signatures.mo`, 'utf-8');
+
+const file = {
+    uri: `${rootUri}/signatures.mo`,
+    textDocument: {
+        uri: `${rootUri}/signatures.mo`,
+        languageId: 'motoko',
+        version: 1,
+        text: text,
+    },
+};
+
+describe('signanureHelp', () => {
+    let client: Connection;
+    let server: Connection;
+
+    beforeAll(async () => {
+        [client, server] = setupClientServer(true);
+
+        const serverInitialized = waitForNotification(
+            'custom/initialized',
+            client,
+        );
+
+        await client.sendRequest<InitializeResult>(
+            'initialize',
+            clientInitParams(rootUri),
+        );
+
+        await client.sendNotification('initialized', {});
+
+        await serverInitialized;
+
+        await client.sendNotification('textDocument/didOpen', {
+            textDocument: file.textDocument,
+        });
+        await wait(0.5);
+    });
+    afterAll(async () => {
+        await client.sendRequest('shutdown');
+        await wait(2);
+        client.dispose();
+        server.dispose();
+    });
+
+    test('triggered signature help with first parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //             ^
+                position: {
+                    line: 2,
+                    character: 20,
+                },
+                context: {
+                    triggerKind: 2,
+                    triggerCharacter: '(',
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('triggered signature help with second parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //                  ^
+                position: {
+                    line: 2,
+                    character: 25,
+                },
+                context: {
+                    triggerKind: 2,
+                    triggerCharacter: ',',
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 1,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('invoke signature help with first parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //             ^
+                position: {
+                    line: 2,
+                    character: 20,
+                },
+                context: {
+                    triggerKind: 1,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('invoke signature help with second parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //                  ^
+                position: {
+                    line: 2,
+                    character: 25,
+                },
+                context: {
+                    triggerKind: 1,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 1,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('change signature help with first parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //             ^
+                position: {
+                    line: 2,
+                    character: 20,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 1,
+                    },
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('change signature help with second parameter', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //               ^
+                position: {
+                    line: 2,
+                    character: 22,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 0,
+                    },
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 1,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test("remove signature help outside function parameters (after ')')", async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //                        ^
+                position: {
+                    line: 2,
+                    character: 31,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 1,
+                    },
+                },
+            },
+        );
+
+        const expected = null;
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test("remove signature help outside function parameters (before '(')", async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // let x1 = f1(1, "qwerty");
+                //            ^
+                position: {
+                    line: 2,
+                    character: 19,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 0,
+                    },
+                },
+            },
+        );
+
+        const expected = null;
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('remove signature help outside function parameters (move line up)', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                position: {
+                    line: 1,
+                    character: 20,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 0,
+                    },
+                },
+            },
+        );
+
+        const expected = null;
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('update signature help after move to another function (move line down)', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f2((1, "bar"), [1,2,3], {a = 1; b = "baz"});
+                //             ^
+                position: {
+                    line: 3,
+                    character: 20,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: true,
+                    activeSignatureHelp: {
+                        signatures: [
+                            {
+                                label: 'f1(a : Int, b : Text) -> Int',
+                                parameters: [
+                                    { label: [3, 10] },
+                                    { label: [11, 20] },
+                                ],
+                            },
+                        ],
+                        activeSignature: 0,
+                        activeParameter: 0,
+                    },
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f2(a : (Int, Text), b : [Int], c : {a : Int; b : Text}) -> ()',
+                    parameters: [
+                        { label: [3, 18] },
+                        { label: [19, 29] },
+                        { label: [30, 54] },
+                    ],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('ignore block comments and strings in signature', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f1(/* first parameter */ 1, /* second parameter */ "f1(1, \"qwerty\")"); // f1(1, "qwerty");
+                //                                                        ^
+                position: {
+                    line: 4,
+                    character: 72,
+                },
+                context: {
+                    triggerKind: 1,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 1,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('ignore line comments', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f1(/* first parameter */ 1, /* second parameter */ "f1(1, \"qwerty\")"); // f1(1, "qwerty");
+                //                                                                                    ^
+                position: {
+                    line: 4,
+                    character: 100,
+                },
+                context: {
+                    triggerKind: 1,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = null;
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('function call with generics as function argument #1', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f1(f3</* integer(,*/ Int, /* text ,) */ Text>(1, "qwerty"), "qweqwe");
+                //          ^
+                position: {
+                    line: 5,
+                    character: 25,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f1(a : Int, b : Text) -> Int',
+                    parameters: [{ label: [3, 10] }, { label: [11, 20] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('function call with generics as function argument #2', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f1(f3</* integer(,*/ Int, /* text ,) */ Text>(1, "qwerty"), "qweqwe");
+                //                                               ^
+                position: {
+                    line: 5,
+                    character: 62,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f3<A, B>(a : A, b : B) -> Int',
+                    parameters: [{ label: [9, 14] }, { label: [15, 21] }],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+
+    test('function as function argument', async () => {
+        const signatureHelp = await client.sendRequest<SignatureHelp>(
+            'textDocument/signatureHelp',
+            {
+                textDocument: {
+                    uri: `${file.uri}`,
+                },
+                // f4(f1, 1, "");
+                //     ^
+                position: {
+                    line: 6,
+                    character: 12,
+                },
+                context: {
+                    triggerKind: 3,
+                    isRetrigger: false,
+                },
+            },
+        );
+
+        const expected = {
+            signatures: [
+                {
+                    label: 'f4(f : (a : Int, b : Text) -> Int, a : Int, b : Text) -> ()',
+                    parameters: [
+                        { label: [3, 33] },
+                        { label: [34, 42] },
+                        { label: [43, 52] },
+                    ],
+                },
+            ],
+            activeSignature: 0,
+            activeParameter: 0,
+        };
+
+        expect(signatureHelp).toEqual(expected);
+    });
+});

--- a/test/signatureHelp/signatures.mo
+++ b/test/signatureHelp/signatures.mo
@@ -1,0 +1,14 @@
+module {
+    func test () {
+        let x1 = f1(1, "qwerty");
+        f2((1, "bar"), [1,2,3], {a = 1; b = "baz"});
+        let x3 = f1(/* first parameter */ 1, /* second parameter */ "f1(1, \"qwerty\")"); // f1(1, "qwerty");
+        let y = f1(f3</* integer(,*/ Int, /* text ,) */ Text>(1, "qwerty"), "qweqwe");
+        f4(f1, 1, "");
+    };
+
+    func f1 (a: Int, b: Text): Int {return a}; 
+    func f2 (a: (Int, Text), b: [Int], c: {a:Int; b: Text}) {};
+    func f3<A, B> (a: A, b: B): Int {return 1;};
+    func f4 (f: (a: Int, b: Text) -> Int, a: Int, b: Text) {}
+}


### PR DESCRIPTION
Problem: Currently signature help handler of Language Server is not implemented.

Solution: Implement the signature help handler and integrate it into the Language Server. Write test suite regarding new functionality.

The signature help handler is implemented in a separate module. I'd suggest to refactor all other handlers and move them also in separate modules, since `handlers.ts` became quite big.

How it works in the user interface is shown in the following screencast:

https://github.com/user-attachments/assets/cf8ba049-2e97-4980-8609-55537edb5a14

